### PR TITLE
Prepare PyPi release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# Changes in Version 1.1.3:
+- improved determinism
+- restored compatibility with scikit-image < 0.19
+
 # Changes in Version 1.1.0:
 - docstring updated
 - validation of arguments that are passed to corrupt()

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+imagecorruptions-imaug
+Copyright 2024 imaug
+
+The imagecorruptions-imaug package
+(https://github.com/imaug/imagecorruptions) is a fork of the imagecorruptions
+package and contains modifications created by the imaug team (https://github.com/imaug).
+
+The imagecorruptions package (https://github.com/bethgelab/imagecorruptions) is an
+extension of the robustness script collection and was create by Evgenia Rusak
+and Benjamin Mitzkus as members of the Bethge Lab (https://bethgelab.org/).
+Copyright 2019 - 2024 Evgenia Rusak. All Rights Reserved.
+Copyright 2019 - 2024 Benjamin Mitzkus. All Rights Reserved.
+
+The robustness script collection (https://github.com/hendrycks/robustness)
+was created by Dan Hendrycks.
+Copyright 2018 - 2022 Dan Hendrycks. All Rights Reserved.
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # imagecorruptions
 This package provides a set of corruptions that can be applied to images in order to benchmark the robustness of neural networks. These corruptions are not meant to be used as training data augmentation but rather to test the networks against unseen perturbations. For more information have a look at the paper on the original corruption package by Hendrycks and Dietterich: [Benchmarking Neural Network Robustness to Common Corruptions and Surface Variations](https://arxiv.org/abs/1807.01697).
 
-![image corruptions](https://raw.githubusercontent.com/bethgelab/imagecorruptions/master/assets/corruptions_sev_3.png?token=ACY4L7YQWNOLTMRRO53U6FS5G3UF6)
+![image corruptions](https://github.com/imaug/imagecorruptions/blob/e8f033db8c76539561c876fae62d196146b2ff30/assets/corruptions_sev_3.png)
 
 ## Installation and Usage
 This package is pip installable via `pip3 install imagecorruptions`. An example of how to use the corruption function is given below:

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,13 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="imagecorruptions",
-    version="1.1.2",
-    author="Evgenia Rusak, Benjamin Mitzkus",
-    author_email="evgenia.rusak@bethgelab.org, benjamin.mitzkus@bethgelab.org",
+    version="1.1.3",
+    author="imaug",
+    author_email="ej_foss@mailbox.org",
     description="This package provides a set of image corruptions.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/bethgelab/imagecorruptions",
+    url="https://github.com/imaug/imagecorruptions",
     packages=setuptools.find_packages(),
     install_requires=[
           'numpy >= 1.16',


### PR DESCRIPTION
The downstream `imaug` release relies on a PyPi release of a modified `imagecorruptions` version.

Prepare the corresponding packaging information for the upcoming release.